### PR TITLE
fix: use port 3005 by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import app from './app'
 
-app.listen(process.env.PORT || 3002)
+app.listen(process.env.PORT || 3005)


### PR DESCRIPTION
@benadida said this was the next available hardcoded number for votingworks service ports.

Closes #3