### PR TITLE
feat: add `/status` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,23 @@ body. Use the `Content-Type` header to choose the print format.
 
 **Example: Printing a PDF file**
 
+Responds with an ID for the print job.
+
 ```sh
 $ curl \
   --request POST \
   --header 'Content-Type: application/pdf' \
   --data-binary @path/to/file.pdf \
   http://localhost:${PORT}/jobs/new
+{"id":"43a55850-c84c-11e9-aff5-bf39225c9e96"}
+```
+
+#### `GET /status`
+
+Responds with a static value just so you can verify the server is running.
+
+```sh
+$ curl http://localhost:${PORT}/status
 ```
 
 ## Mock a Printer

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,26 +1,26 @@
 import express from 'express'
 import jobsNewRoute from './routes/jobs/new'
+import statusRoute from './routes/status'
 import { setPrintManager } from './manager'
 import RealPrintManager from './manager/RealPrintManager'
 
-/** ********* */
 /* Printing */
-/** ********* */
 
 setPrintManager(new RealPrintManager())
 
-/** ******* */
 /* Server */
-/** ******* */
 
 const app = express()
 
+// Always read request body into a Buffer.
 app.use(
   express.raw({
     type: () => true,
     limit: '10mb',
   })
 )
+
+app.get('/status', statusRoute)
 app.post('/jobs/new', jobsNewRoute)
 
 export default app

--- a/src/routes/status.test.ts
+++ b/src/routes/status.test.ts
@@ -1,0 +1,8 @@
+import request from 'supertest'
+import app from '../app'
+
+test('responds with ok: true', async () => {
+  await request(app)
+    .get('/status')
+    .expect(200, { ok: true })
+})

--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from 'express'
+
+const route: RequestHandler = (_req, res) => {
+  res.send({ ok: true }).end()
+}
+
+export default route


### PR DESCRIPTION

This allows clients to test whether the print server is available.

Closes #1