### PR TITLE
feat: add available print types to /print/status

### DIFF
--- a/src/routes/printer/status.test.ts
+++ b/src/routes/printer/status.test.ts
@@ -5,6 +5,60 @@ import fakePrintManager from '../../../test/utils/fakePrintManager'
 test('responds with ok: true', async () => {
   await request(makeApp(fakePrintManager()))
     .get('/printer/status')
-    .expect({ ok: true })
+    .expect(res => {
+      expect(res.body).toMatchObject({ ok: true })
+    })
     .expect(200)
+})
+
+test('responds with available print types', async () => {
+  await request(makeApp(fakePrintManager()))
+    .get('/printer/status')
+    .expect(res => {
+      expect(res.body).toMatchObject({ available: expect.any(Array) })
+    })
+})
+
+test('responds that text/html is available', async () => {
+  await request(makeApp(fakePrintManager()))
+    .get('/printer/status')
+    .expect(res => {
+      expect(res.body).toMatchObject({
+        available: expect.arrayContaining([{ contentType: 'text/html' }]),
+      })
+    })
+})
+
+test('responds that application/pdf is available', async () => {
+  await request(makeApp(fakePrintManager()))
+    .get('/printer/status')
+    .expect(res => {
+      expect(res.body).toMatchObject({
+        available: expect.arrayContaining([{ contentType: 'application/pdf' }]),
+      })
+    })
+})
+
+test('responds that x-application/pdfmake is available', async () => {
+  await request(makeApp(fakePrintManager()))
+    .get('/printer/status')
+    .expect(res => {
+      expect(res.body).toMatchObject({
+        available: expect.arrayContaining([
+          { contentType: 'x-application/pdfmake', fonts: ['HelveticaNeue'] },
+        ]),
+      })
+    })
+})
+
+test('responds that application/octet-stream is available', async () => {
+  await request(makeApp(fakePrintManager()))
+    .get('/printer/status')
+    .expect(res => {
+      expect(res.body).toMatchObject({
+        available: expect.arrayContaining([
+          { contentType: 'application/octet-stream' },
+        ]),
+      })
+    })
 })

--- a/src/routes/printer/status.ts
+++ b/src/routes/printer/status.ts
@@ -1,10 +1,30 @@
 import { RequestHandler } from 'express'
+import fonts from '../../utils/fonts'
 
 /**
  * Builds a request handler for a status endpoint.
  */
 export default function makeRoute(): RequestHandler {
   return (_req, res): void => {
-    res.send({ ok: true }).end()
+    res
+      .send({
+        ok: true,
+        available: [
+          {
+            contentType: 'text/html',
+          },
+          {
+            contentType: 'application/pdf',
+          },
+          {
+            contentType: 'x-application/pdfmake',
+            fonts: Object.getOwnPropertyNames(fonts),
+          },
+          {
+            contentType: 'application/octet-stream',
+          },
+        ],
+      })
+      .end()
   }
 }


### PR DESCRIPTION
This will be used by anything that wants to be able to print e.g. PDF documents. BMD pull request will come momentarily.